### PR TITLE
Add robots.txt and site_url for SEO

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /site
 .cache
+.idea

--- a/docs/robots.txt
+++ b/docs/robots.txt
@@ -1,0 +1,3 @@
+User-agent: *
+Disallow:
+Sitemap: https://spark.docs.iitmotorsports.org/sitemap.xml

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,6 @@
 site_name: ⚡ Spark Book ⚡
 site_author: 'Noah Husby'
+site_url: https://spark.docs.iitmotorsports.org
 docs_dir: docs/
 repo_name: 'iitmotorsports/spark'
 repo_url: 'https://github.com/iitmotorsports/spark'


### PR DESCRIPTION
## Breaking changes

N/A

## Proposed change

Adds robots.txt to allow crawlers to index the site. The `site_url` parameter was set to allow sitemap.xml to be generated properly.